### PR TITLE
Reference working websocket.io branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "open": "0.0.5",
     "openport": "0.0.4",
     "send": "^0.14.1",
-    "websocket.io": "git://github.com/LearnBoost/websocket.io#5f0b3799f50944bc4d1eb58acdef61c38883d6cf"
+    "websocket.io": "git://github.com/kewisch/websocket.io#require-events"
   },
   "devDependencies": {
     "connect-livereload": "^0.6.0",


### PR DESCRIPTION
Close #19

In commit b449a88 ("Use a specific unreleased commit of Website.io until
it get released later.", 2017-01-17) we needed an unreleased fix to
websocket.io. It seems that either GitHub or NPM has lost the option to
reference commits linked through another fork. This fixes #19 by
referencing the original author's branch.

This unreleased version is required because websocket.io is broken on
Node 7+. Unfortunately it seems that the websocket.io authors no longer
are interested in keeping their package Node 7+ compatible. (Discussion
at https://github.com/LearnBoost/websocket.io/pull/57).

There still exists the following caveats:

* If @kewisch wishes to remove his fork then this will no longer work
* Official support seems lacking
* This program is dependent on an unstable package

I suggest investigating the possibility of using an alternative
websocket package with less problems.